### PR TITLE
Fix misplaced logic

### DIFF
--- a/hackertracker/HTScheduleTableViewController.swift
+++ b/hackertracker/HTScheduleTableViewController.swift
@@ -35,9 +35,13 @@ class BaseScheduleTableViewController: UITableViewController, EventDetailDelegat
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if isViewLoaded {
+        if isViewLoaded && !animated  {
             reloadEvents()
-            tableView.scrollToNearestSelectedRow(at: UITableViewScrollPosition.middle, animated: false)
+
+            if let lastContentOffset = lastContentOffset {
+                tableView.contentOffset = lastContentOffset
+                tableView.layoutIfNeeded()
+            }
         }
     }
 
@@ -66,14 +70,6 @@ class BaseScheduleTableViewController: UITableViewController, EventDetailDelegat
             tableView.addSubview(refreshControl!)
         }
 
-        if isViewLoaded && !animated  {
-            reloadEvents()
-
-            if let lastContentOffset = lastContentOffset {
-                tableView.contentOffset = lastContentOffset
-                tableView.layoutIfNeeded()
-            }
-        }
     }
 
     func reloadEvents() {


### PR DESCRIPTION
This was the fix for section headers being in the wrong place when leaving and returning to the scheduleViewController.  Somehow the logic ended up in viewDidAppear when it needs to be in viewWillAppear.