### PR TITLE
Support for iPad Multitasking fixes #130

### DIFF
--- a/hackertracker/Info.plist
+++ b/hackertracker/Info.plist
@@ -51,7 +51,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
Quite simple change that allows multitasking on iPad via Split View and Slide Over.

There is no downside to changing `UIRequiresFullScreen` from `true` to `false` as this setting was added specifically to disable Split View and Slide Over functionality.

I have tested the app in both these views and it works perfectly fine, it's just a really tall iPhone 5s which all the screens seem to scale to relatively well already 👍🏻