### PR TITLE
Replace ... with ..< for safer range creation fixes #129

### DIFF
--- a/hackertracker/HTMapsViewController.swift
+++ b/hackertracker/HTMapsViewController.swift
@@ -69,7 +69,7 @@ class HTMapsViewController: UIViewController, UIScrollViewDelegate {
 
         var selectedIndex = 0
         if let h = hotel {
-            for i in 0...(mapSwitch.numberOfSegments-1) {
+            for i in 0..<mapSwitch.numberOfSegments {
                 if let m = mapSwitch.titleForSegment(at: i) {
                     if m.contains(h) {
                         selectedIndex = i
@@ -123,7 +123,9 @@ class HTMapsViewController: UIViewController, UIScrollViewDelegate {
     }
     
     @IBAction func mapChanged(_ sender: UISegmentedControl) {
-        for i in 0...AnonymousSession.shared.currentConference.maps.count-1 {
+        guard mapViews.count < 0 else { return }
+        
+        for i in 0..<AnonymousSession.shared.currentConference.maps.count {
                 mapViews[i].isHidden = true
                 mapViews[i].isUserInteractionEnabled = false
         }

--- a/hackertracker/HTScheduleTableViewController.swift
+++ b/hackertracker/HTScheduleTableViewController.swift
@@ -215,9 +215,9 @@ class BaseScheduleTableViewController: UITableViewController, EventDetailDelegat
         // Debug below to jump to next events for DEFCON27 schedule
         //let curDate = DateFormatterUtility.shared.iso8601Formatter.date(from: "2019-08-09T11:43:01.000-0700")!
         if self.eventSections.count > 0 {
-            fullloop: for i in 0...(self.eventSections.count-1) {
+            fullloop: for i in 0..<self.eventSections.count {
                 if self.eventSections[i].events.count > 0 {
-                    for j in 0...(self.eventSections[i].events.count-1) {
+                    for j in 0..<self.eventSections[i].events.count {
                         let e = self.eventSections[i].events[j]
                         if e.event.begin > curDate {
                             //NSLog("Jumping to \(e.event.title) at \(i):\(j)")


### PR DESCRIPTION
Tapping the name of a location on the event detail screen will no longer cause the app to crash. It will show an empty map controller as a sheet. Originally I was going to disable selection completely, or fix it with an empty state, but for now left it as-is since the top-level map controller has the same issue.