### PR TITLE
Fix add to calendar

### DIFF
--- a/hackertracker/CalendarUtility.swift
+++ b/hackertracker/CalendarUtility.swift
@@ -7,8 +7,8 @@
 //
 
 import EventKit
-import EventKitUI
 import Foundation
+import UIKit
 
 struct CalendarUtility {
     let eventStore = EKEventStore()

--- a/hackertracker/CalendarUtility.swift
+++ b/hackertracker/CalendarUtility.swift
@@ -97,18 +97,18 @@ struct CalendarUtility {
     }
 
     private func deniedAccessAlert(view: HTEventDetailViewController) {
-        let saveAlert = UIAlertController(
+        let deniedAlert = UIAlertController(
             title: "Calendar access is currently disabled for HackerTracker",
             message: "Select OK to view application settings", preferredStyle: .alert
         )
-        saveAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        saveAlert.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+        deniedAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        deniedAlert.addAction(UIAlertAction(title: "OK", style: .default) { _ in
             if let url = URL(string: UIApplication.openSettingsURLString) { if UIApplication.shared.canOpenURL(url) { UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }
             }
         })
 
-        view.present(saveAlert, animated: true, completion: nil)
+        view.present(deniedAlert, animated: true, completion: nil)
     }
 
     private func duplicateAlert(htEvent: HTEventModel, view: HTEventDetailViewController) {

--- a/hackertracker/CalendarUtility.swift
+++ b/hackertracker/CalendarUtility.swift
@@ -86,7 +86,7 @@ struct CalendarUtility {
     private func saveAlert(htEvent: HTEventModel, event: EKEvent, view: HTEventDetailViewController) {
         let saveAlert = UIAlertController(
             title: "Add \(htEvent.conferenceName) event to calendar",
-            message: "\(htEvent.title)\n[\(htEvent.type.name)]\n\n\(htEvent.location.name)", preferredStyle: .alert
+            message: htEvent.title, preferredStyle: .alert
         )
         saveAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         saveAlert.addAction(UIAlertAction(title: "Save", style: .default) { _ in

--- a/hackertracker/CalendarUtility.swift
+++ b/hackertracker/CalendarUtility.swift
@@ -13,9 +13,7 @@ import UIKit
 struct CalendarUtility {
     let eventStore = EKEventStore()
 
-    var status: EKAuthorizationStatus {
-        EKEventStore.authorizationStatus(for: EKEntityType.event)
-    }
+    let status: EKAuthorizationStatus = EKEventStore.authorizationStatus(for: EKEntityType.event)
 
     func requestAuthorization() {
         eventStore.requestAccess(to: EKEntityType.event) { _, error in

--- a/hackertracker/CalendarUtility.swift
+++ b/hackertracker/CalendarUtility.swift
@@ -23,11 +23,22 @@ struct CalendarUtility {
         }
     }
 
+    func requestAuthorizationAndSave(htEvent: HTEventModel, view: HTEventDetailViewController) {
+        eventStore.requestAccess(to: EKEntityType.event) { authorized, error in
+            if authorized {
+                DispatchQueue.main.async {
+                    self.addEventToCalendar(htEvent: htEvent, view: view)
+                }
+            }
+            if let error = error {
+                print("Request authorization error: \(error.localizedDescription)")
+            }
+        }
+    }
     func addEvent(htEvent: HTEventModel, view: HTEventDetailViewController) {
         switch status {
         case .notDetermined:
-            requestAuthorization()
-            addEvent(htEvent: htEvent, view: view)
+            requestAuthorizationAndSave(htEvent: htEvent, view: view)
         case .authorized:
             addEventToCalendar(htEvent: htEvent, view: view)
         case .restricted, .denied:

--- a/hackertracker/CalendarUtility.swift
+++ b/hackertracker/CalendarUtility.swift
@@ -35,6 +35,7 @@ struct CalendarUtility {
             }
         }
     }
+
     func addEvent(htEvent: HTEventModel, view: HTEventDetailViewController) {
         switch status {
         case .notDetermined:
@@ -42,7 +43,7 @@ struct CalendarUtility {
         case .authorized:
             addEventToCalendar(htEvent: htEvent, view: view)
         case .restricted, .denied:
-            break
+            deniedAccessAlert(view: view)
         @unknown default:
             break
         }
@@ -90,6 +91,21 @@ struct CalendarUtility {
         saveAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         saveAlert.addAction(UIAlertAction(title: "Save", style: .default) { _ in
             try? self.eventStore.save(event, span: .thisEvent)
+        })
+
+        view.present(saveAlert, animated: true, completion: nil)
+    }
+
+    private func deniedAccessAlert(view: HTEventDetailViewController) {
+        let saveAlert = UIAlertController(
+            title: "Calendar access is currently disabled for HackerTracker",
+            message: "Select OK to view application settings", preferredStyle: .alert
+        )
+        saveAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        saveAlert.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+            if let url = URL(string: UIApplication.openSettingsURLString) { if UIApplication.shared.canOpenURL(url) { UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+            }
         })
 
         view.present(saveAlert, animated: true, completion: nil)

--- a/hackertracker/HTEventDetailViewController.swift
+++ b/hackertracker/HTEventDetailViewController.swift
@@ -10,8 +10,6 @@ import UIKit
 import CoreData
 import UserNotifications
 import SafariServices
-import EventKit
-import EventKitUI
 
 protocol EventDetailDelegate {
     func reloadEvents()


### PR DESCRIPTION
- Attempt to fix crash after asking for calendar permissions
- Add notification when permissions are denied (and optionally direct users to app settings)
- Remove event type and location information from save event alert message