### PR TITLE
Remove remaining workspace files

### DIFF
--- a/hackertracker.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/hackertracker.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>


### PR DESCRIPTION
The move from CocoaPods to SPM meant the xcworkspace is no longer required.

But there was a lingering file, which meant that running `xed .` from the terminal would open an empty xcworkspace instead of opening the xcodeproj file.