### PR TITLE
Reload events after event details bookmark action

### DIFF
--- a/hackertracker/HTEventDetailViewController.swift
+++ b/hackertracker/HTEventDetailViewController.swift
@@ -341,6 +341,7 @@ class HTEventDetailViewController: UIViewController { // swiftlint:disable:this 
         }
 
         addBookmark(bookmark: bookmark, event: event)
+        self.delegate?.reloadEvents()
     }
 
     func reloadEvents() {


### PR DESCRIPTION
Fixed bug of state on schedule view not updating after adding or removing bookmark on the event details view. 